### PR TITLE
add options to pass data

### DIFF
--- a/src/notiwind.types.ts
+++ b/src/notiwind.types.ts
@@ -2,6 +2,9 @@ export interface NotificationGenerator {
     group: string;
     title: string;
     text: string;
+    options: {
+        [key: string]: any
+    }
 }
 
 export interface Notification {
@@ -9,6 +12,9 @@ export interface Notification {
     group: string;
     title: string;
     text: string;
+    options: {
+        [key: string]: any
+    }
 }
 
 export interface AddSignature {


### PR DESCRIPTION
Hi!

I added types to pass `type` and `options`

this can used for select notification type like `success`, `error`, `info`, etc,
and options to pass data can be needed.

based in the example `Using different types of notifcations`